### PR TITLE
fix DefaultProcess file path

### DIFF
--- a/src/Structures/NezuGateway.ts
+++ b/src/Structures/NezuGateway.ts
@@ -238,15 +238,13 @@ export class NezuGateway extends EventEmitter {
         } else if (process.env.USE_PROCESS_SHARDING === "true") {
             this.ws.setStrategy(
                 new ProcessShardingStrategy(this.ws, {
-                    shardsPerWorker: Number(process.env.GATEWAY_SHARDS_PERWORKERS ?? 9),
-                    workerPath: "../Utilities/Websocket/DefaultProcess.js"
+                    shardsPerWorker: Number(process.env.GATEWAY_SHARDS_PERWORKERS ?? 9)
                 })
             );
         } else {
             this.ws.setStrategy(
                 new WorkerShardingStrategy(this.ws, {
-                    shardsPerWorker: Number(process.env.GATEWAY_SHARDS_PERWORKERS ?? 9),
-                    workerPath: "../Utilities/Websocket/DefaultProcess.js"
+                    shardsPerWorker: Number(process.env.GATEWAY_SHARDS_PERWORKERS ?? 9)
                 })
             );
         }

--- a/src/Utilities/Websocket/ProcessShardingStrategy.ts
+++ b/src/Utilities/Websocket/ProcessShardingStrategy.ts
@@ -4,6 +4,10 @@ import { ChildProcess, fork } from "node:child_process";
 import { Collection } from "@discordjs/collection";
 import { GatewaySendPayload } from "discord-api-types/v10";
 import { IdentifyThrottler, WebSocketManager, WebSocketShardDestroyOptions, WebSocketShardStatus, managerToFetchingStrategyOptions, IShardingStrategy, WorkerShardingStrategyOptions, WorkerData, WorkerSendPayload, WorkerSendPayloadOp, WorkerReceivePayload, WorkerReceivePayloadOp } from "@discordjs/ws";
+import * as url from "url";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 /**
 * Strategy used to spawn threads in worker_threads


### PR DESCRIPTION
ES modules do not support __dirname, so we add a custom __dirname pointing to the correct default process as the default workerPath.

For future reference:
When specifying a different workerPath in NezuGateway, the path is relative to the node execution path, not current file path.